### PR TITLE
core 0.7.9 compatibility

### DIFF
--- a/module.json
+++ b/module.json
@@ -5,7 +5,7 @@
   "author": "dev7355608",
   "version": "1.2.13",
   "minimumCoreVersion": "0.7.8",
-  "compatibleCoreVersion": "0.7.8",
+  "compatibleCoreVersion": "0.7.9",
   "scripts": [
     "perfect-vision.js"
   ],

--- a/perfect-vision.js
+++ b/perfect-vision.js
@@ -589,6 +589,14 @@ class PerfectVision {
         if (this._refresh) {
             this._refresh = false;
 
+            let devicePixelRatioSetting;
+
+            try {
+                devicePixelRatioSetting = game.settings.get("core", "devicePixelRatio");
+            } catch (error) {
+                devicePixelRatioSetting = 1;
+            }
+
             const mask = this._mask;
 
             const width = canvas.app.renderer.screen.width;
@@ -599,7 +607,7 @@ class PerfectVision {
                     width: width,
                     height: height,
                     scaleMode: PIXI.SCALE_MODES.LINEAR,
-                    resolution: game.settings.get("core", "devicePixelRatio") ?
+                    resolution: devicePixelRatioSetting ?
                         Math.max(window.devicePixelRatio, 1) : Math.min(window.devicePixelRatio, 1)
                 });
             } else if (mask.texture.width !== width || mask.texture.height !== height) {

--- a/perfect-vision.js
+++ b/perfect-vision.js
@@ -589,14 +589,6 @@ class PerfectVision {
         if (this._refresh) {
             this._refresh = false;
 
-            let devicePixelRatioSetting;
-
-            try {
-                devicePixelRatioSetting = game.settings.get("core", "devicePixelRatio");
-            } catch (error) {
-                devicePixelRatioSetting = 1;
-            }
-
             const mask = this._mask;
 
             const width = canvas.app.renderer.screen.width;
@@ -607,8 +599,7 @@ class PerfectVision {
                     width: width,
                     height: height,
                     scaleMode: PIXI.SCALE_MODES.LINEAR,
-                    resolution: devicePixelRatioSetting ?
-                        Math.max(window.devicePixelRatio, 1) : Math.min(window.devicePixelRatio, 1)
+                    resolution: canvas.app.renderer.resolution
                 });
             } else if (mask.texture.width !== width || mask.texture.height !== height) {
                 mask.texture.resize(width, height);


### PR DESCRIPTION
Resolves #24 

Foundry Core v0.7.9 removes the devicePixelRatio game setting, which makes this setting getter throw an error instead of return a value. Wrapping that setting getter in a try catch prevents the thrown error from causing perfectVision to fail on startup pretty catastrophically.