### PR TITLE
Revert just setting sight filter instead of also setting mono filter

### DIFF
--- a/perfect-vision.js
+++ b/perfect-vision.js
@@ -374,9 +374,10 @@ class PerfectVision {
             mask.mask = null;
         }
 
+        this._monoFilter.enabled = canvas.sight.tokenVision && canvas.sight.sources.size > 0;
         this._monoFilter.uniforms.uTint = monoVisionColor ?? [1, 1, 1];
 
-        this._sightFilter.enabled = canvas.sight.tokenVision && canvas.sight.sources.size > 0;
+        this._sightFilter.enabled = this._monoFilter.enabled;
 
         const ilm = canvas.lighting.illumination;
         const ilm_ = this._extend(ilm);


### PR DESCRIPTION
Hey @dev7355608,

here is my final Pull Request (for now ;) ), which fixes [Issue 38](https://github.com/dev7355608/perfect-vision/issues/38), by undoing a minor change introduced from the last commit on main.
I have also tested if all my Pull Requests merge properly and there shouldn't be any problems. If there is something open whatsoever, do not hesitate to contact me.


Cheers!
-Si